### PR TITLE
added php-zip to list of required PHP packages

### DIFF
--- a/installation/requirements.md
+++ b/installation/requirements.md
@@ -51,11 +51,12 @@ Das Kommando muss mit folgenden Paketen aufgerufen werden.
 | `php-common` | |
 | `php-curl` | |
 | `php-gd` | |
+| `php-log` | |
 | `php-mbstring` | |
 | `php-mcrypt` | |
 | `php-mysql` | |
 | `php-xsl` | |
-| `php-log` | |
+| `php-zip` | |
 | `libapache2-mod-php` | |
 |------|
 | Für die Entwicklung: |


### PR DESCRIPTION
Für die SWORD-Schnittstelle muss `php-zip` installiert werden, wenn ZIP-Files hochgeladen werden sollen.